### PR TITLE
Use --cli-input-json in create table command

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -91,17 +91,11 @@ function stop_local_dynamo {
 function create_tables {
   local local_dynamo_endpoint=http://localhost:"${local_dynamo_port}"
   for table in "${tables[@]}"; do
-    local schema_file attributes key_schema gsis
+    local schema_file table_json
     schema_file="${tmp_dir}/${table}.json"
-    attributes=$(jq '.["Table"]."AttributeDefinitions"' "${schema_file}")
-    key_schema=$(jq '.["Table"]."KeySchema"' "${schema_file}")
-    gsis=$(jq '[.["Table"]."GlobalSecondaryIndexes"[] | {Projection: .Projection, IndexName: .IndexName, KeySchema: .KeySchema }]' "${schema_file}")
+    table_json=$(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${schema_file}")
     aws dynamodb create-table \
-      --table-name "${table}" \
-      --attribute-definitions "${attributes}" \
-      --key-schema "${key_schema}" \
-      --global-secondary-indexes "${gsis}" \
-      --billing-mode 'PAY_PER_REQUEST' \
+      --cli-input-json "${table_json}" \
       --region "local" --endpoint ${local_dynamo_endpoint}
   done
   aws dynamodb list-tables --region "local" --endpoint ${local_dynamo_endpoint}


### PR DESCRIPTION
Instead of adding arguments to `aws dynamodb create-table` individually, this change creates a single JSON string that can be passed to `--cli-input-json` instead. `GlobalSecondaryIndexes` and `LocalSecondaryIndexes` only get added to this JSON string if they exist.