### PR TITLE
Use dynamic port when running local dynamo

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -89,8 +89,10 @@ function stop_local_dynamo {
 
 # Create the tables in the local Dynamo image
 function create_tables {
-  local local_dynamo_endpoint
-  local_dynamo_endpoint=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}")
+  local local_dynamo_endpoint container_port
+  container_port=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}" | cut -d':' -f2)
+  echo "Waiting for local DynamoDB to start on port ${container_port}"
+  local_dynamo_endpoint=http://localhost:"${container_port}"
   echo "Creating tables in local DynamoDB at ${local_dynamo_endpoint}"
   for table in "${tables[@]}"; do
     local schema_file table_json

--- a/hooks/command
+++ b/hooks/command
@@ -73,7 +73,7 @@ function retrieve_schemas {
 # Pulls local DynamoDB and runs it on port 8000
 function start_local_dynamo {
   docker pull amazon/dynamodb-local:latest
-  local_dynamo_container_id=$(docker run -d -p "${local_dynamo_port}":"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
+  local_dynamo_container_id=$(docker run -d -p 0:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
   sleep 5 # TODO: This gives the container a bit of time to start up, but it would be better to poll for when its up instead
 }
 
@@ -89,16 +89,17 @@ function stop_local_dynamo {
 
 # Create the tables in the local Dynamo image
 function create_tables {
-  local local_dynamo_endpoint=http://localhost:"${local_dynamo_port}"
+  local local_dynamo_endpoint
+  local_dynamo_endpoint=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}")
   for table in "${tables[@]}"; do
     local schema_file table_json
     schema_file="${tmp_dir}/${table}.json"
     table_json=$(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${schema_file}")
     aws dynamodb create-table \
       --cli-input-json "${table_json}" \
-      --region "local" --endpoint ${local_dynamo_endpoint}
+      --region "local" --endpoint http://"${local_dynamo_endpoint}"
   done
-  aws dynamodb list-tables --region "local" --endpoint ${local_dynamo_endpoint}
+  aws dynamodb list-tables --region "local" --endpoint http://"${local_dynamo_endpoint}"
 }
 
 # Builds the multi-arch image and publishes it

--- a/hooks/command
+++ b/hooks/command
@@ -73,7 +73,7 @@ function retrieve_schemas {
 # Pulls local DynamoDB and runs it on port 8000
 function start_local_dynamo {
   docker pull amazon/dynamodb-local:latest
-  local_dynamo_container_id=$(docker run -d -p 0:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
+  local_dynamo_container_id=$(docker run -d -p 49154:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
   sleep 5 # TODO: This gives the container a bit of time to start up, but it would be better to poll for when its up instead
 }
 
@@ -91,6 +91,7 @@ function stop_local_dynamo {
 function create_tables {
   local local_dynamo_endpoint
   local_dynamo_endpoint=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}")
+  echo "Creating tables in local DynamoDB at ${local_dynamo_endpoint}"
   for table in "${tables[@]}"; do
     local schema_file table_json
     schema_file="${tmp_dir}/${table}.json"

--- a/hooks/command
+++ b/hooks/command
@@ -91,18 +91,16 @@ function stop_local_dynamo {
 function create_tables {
   local local_dynamo_endpoint container_port
   container_port=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}" | cut -d':' -f2)
-  echo "Waiting for local DynamoDB to start on port ${container_port}"
   local_dynamo_endpoint=http://localhost:"${container_port}"
-  echo "Creating tables in local DynamoDB at ${local_dynamo_endpoint}"
   for table in "${tables[@]}"; do
     local schema_file table_json
     schema_file="${tmp_dir}/${table}.json"
     table_json=$(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${schema_file}")
     aws dynamodb create-table \
       --cli-input-json "${table_json}" \
-      --region "local" --endpoint http://"${local_dynamo_endpoint}"
+      --region "local" --endpoint "${local_dynamo_endpoint}"
   done
-  aws dynamodb list-tables --region "local" --endpoint http://"${local_dynamo_endpoint}"
+  aws dynamodb list-tables --region "local" --endpoint "${local_dynamo_endpoint}"
 }
 
 # Builds the multi-arch image and publishes it

--- a/hooks/command
+++ b/hooks/command
@@ -73,7 +73,7 @@ function retrieve_schemas {
 # Pulls local DynamoDB and runs it on port 8000
 function start_local_dynamo {
   docker pull amazon/dynamodb-local:latest
-  local_dynamo_container_id=$(docker run -d -p 49154:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
+  local_dynamo_container_id=$(docker run -d -p 0:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
   sleep 5 # TODO: This gives the container a bit of time to start up, but it would be better to poll for when its up instead
 }
 


### PR DESCRIPTION
As per https://github.com/seek-oss/dynamodb-image-buildkite-plugin/pull/2#discussion_r1302481058, this PR adds in logic to dynamically choose a port to run local dynamo on.