### PR TITLE
Add BATS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: docker compose run --rm test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,10 @@ services:
     command: ['--id', 'seek-oss/dynamodb-image']
     volumes:
       - ".:/plugin:ro"
+
+  test:
+    image: buildkite/plugin-tester
+    volumes:
+      - ".:/plugin:ro"
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,5 @@ services:
   test:
     image: buildkite/plugin-tester
     volumes:
-      - ".:/plugin:ro"
-
+      - ".:/plugin"
 

--- a/hooks/command
+++ b/hooks/command
@@ -20,39 +20,6 @@ local_dynamo_port=8000
 tmp_dir="${script_dir}/tmp"
 mkdir -p "${tmp_dir}"
 
-# Pulls local DynamoDB and runs it on port 8000
-function start_local_dynamo {
-  docker pull amazon/dynamodb-local:latest
-  local_dynamo_container_id=$(docker run -d -p 0:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
-  sleep 5 # TODO: This gives the container a bit of time to start up, but it would be better to poll for when its up instead
-}
-
-# Saves the database file so that we can use it in the build
-function save_database {
-  docker cp "${local_dynamo_container_id}":/home/dynamodblocal/shared-local-instance.db "${tmp_dir}"/shared-local-instance.db
-}
-
-# Stop running local dynamo
-function stop_local_dynamo {
-  docker stop "${local_dynamo_container_id}"
-}
-
-# Create the tables in the local Dynamo image
-function create_tables {
-  local local_dynamo_endpoint container_port
-  container_port=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}" | cut -d':' -f2)
-  local_dynamo_endpoint=http://localhost:"${container_port}"
-  for table in "${tables[@]}"; do
-    local schema_file table_json
-    schema_file="${tmp_dir}/${table}.json"
-    table_json=$(generate_create_json "${schema_file}")
-    aws dynamodb create-table \
-      --cli-input-json "${table_json}" \
-      --region "local" --endpoint "${local_dynamo_endpoint}"
-  done
-  aws dynamodb list-tables --region "local" --endpoint "${local_dynamo_endpoint}"
-}
-
 # Builds the multi-arch image and publishes it
 function build_and_publish {
   cd "${script_dir}"
@@ -89,9 +56,6 @@ read_tables
 echo "1. Retrieve schemas..."
 retrieve_schemas "${tables[@]}"
 echo "2. Create database file..."
-start_local_dynamo
-create_tables
-save_database
-stop_local_dynamo
+create_database
 echo "3. Build and publish multi-arch images..."
 build_and_publish

--- a/hooks/command
+++ b/hooks/command
@@ -56,6 +56,6 @@ read_tables
 echo "1. Retrieve schemas..."
 retrieve_schemas "${tables[@]}"
 echo "2. Create database file..."
-create_database
+create_database "${tables[@]}"
 echo "3. Build and publish multi-arch images..."
 build_and_publish

--- a/hooks/command
+++ b/hooks/command
@@ -2,13 +2,8 @@
 
 set -euo pipefail
 
-script_dir="$(dirname "${BASH_SOURCE[0]}")"
-tmp_dir="${script_dir}/tmp"
-mkdir -p "${tmp_dir}"
+source "$(dirname "${BASH_SOURCE[0]}")/functions"
 
-source "${script_dir}/functions"
-
-export DOCKER_CLI_EXPERIMENTAL=enabled
 export AWS_PAGER=""
 
 check_null BUILDKITE_BUILD_NUMBER

--- a/hooks/command
+++ b/hooks/command
@@ -2,17 +2,11 @@
 
 set -euo pipefail
 
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
+source "${script_dir}/functions"
+
 export DOCKER_CLI_EXPERIMENTAL=enabled
 export AWS_PAGER=""
-
-function check_null {
-  local var_name="$1"
-  local var_value="${!var_name:-}"
-  if [[ -z "$var_value" ]]; then
-    echo "The environment variable $var_name must be set."
-    exit 1
-  fi
-}
 
 check_null BUILDKITE_BUILD_NUMBER
 check_null BUILDKITE_BRANCH
@@ -21,43 +15,10 @@ check_null BUILDKITE_PIPELINE_DEFAULT_BRANCH
 build="${BUILDKITE_BUILD_NUMBER:-}"
 repository="$BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY"
 tables=()
-script_dir="$(dirname "${BASH_SOURCE[0]}")"
 local_dynamo_container_id=""
 local_dynamo_port=8000
 tmp_dir="${script_dir}/tmp"
 mkdir -p "${tmp_dir}"
-
-# Read a plugin property of type [array, string] into a Bash array. Buildkite
-# exposes a string value at BUILDKITE_PLUGIN_{NAME}_{KEY}, and array values at
-# BUILDKITE_PLUGIN_{NAME}_{KEY}_{IDX}.
-function read_list_property {
-  local prefix="BUILDKITE_PLUGIN_DYNAMODB_IMAGE_${1}"
-  local property="${prefix}_0"
-  result=()
-  if [[ -n ${!property:-} ]]; then
-    local i=0
-    local property="${prefix}_${i}"
-    while [[ -n ${!property:-} ]]; do
-      result+=("${!property}")
-      i=$((i + 1))
-      property="${prefix}_${i}"
-    done
-  elif [[ -n ${!prefix:-} ]]; then
-    result+=("${!prefix}")
-  fi
-  [[ ${#result[@]} -gt 0 ]] || return 1
-}
-
-# Read tables into an array
-function read_tables {
-  if read_list_property 'TABLES'; then
-    for table in "${result[@]}"; do
-      tables+=("${table}")
-    done
-  else
-    echo "A list of tables must be provided."
-  fi
-}
 
 # Retrieves schemas and saves them as JSON
 function retrieve_schemas {

--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ function create_tables {
   for table in "${tables[@]}"; do
     local schema_file table_json
     schema_file="${tmp_dir}/${table}.json"
-    table_json=$(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${schema_file}")
+    table_json=$(generate_create_json "${schema_file}")
     aws dynamodb create-table \
       --cli-input-json "${table_json}" \
       --region "local" --endpoint "${local_dynamo_endpoint}"

--- a/hooks/command
+++ b/hooks/command
@@ -20,17 +20,6 @@ local_dynamo_port=8000
 tmp_dir="${script_dir}/tmp"
 mkdir -p "${tmp_dir}"
 
-# Retrieves schemas and saves them as JSON
-function retrieve_schemas {
-  for table in "${tables[@]}"; do
-    local schema_file="${tmp_dir}/${table}.json"
-    aws dynamodb describe-table \
-      --table-name "${table}" \
-      --output json \
-      >"${schema_file}"
-  done
-}
-
 # Pulls local DynamoDB and runs it on port 8000
 function start_local_dynamo {
   docker pull amazon/dynamodb-local:latest
@@ -98,7 +87,7 @@ function build_and_publish {
 
 read_tables
 echo "1. Retrieve schemas..."
-retrieve_schemas
+retrieve_schemas "${tables[@]}"
 echo "2. Create database file..."
 start_local_dynamo
 create_tables

--- a/hooks/command
+++ b/hooks/command
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
+tmp_dir="${script_dir}/tmp"
+mkdir -p "${tmp_dir}"
+
 source "${script_dir}/functions"
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
@@ -12,46 +15,7 @@ check_null BUILDKITE_BUILD_NUMBER
 check_null BUILDKITE_BRANCH
 check_null BUILDKITE_PIPELINE_DEFAULT_BRANCH
 
-build="${BUILDKITE_BUILD_NUMBER:-}"
-repository="$BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY"
 tables=()
-local_dynamo_container_id=""
-local_dynamo_port=8000
-tmp_dir="${script_dir}/tmp"
-mkdir -p "${tmp_dir}"
-
-# Builds the multi-arch image and publishes it
-function build_and_publish {
-  cd "${script_dir}"
-  local dynamo_port
-  dynamo_port="${BUILDKITE_PLUGIN_DYNAMODB_IMAGE_PORT:-8000}"
-  docker buildx create --use
-  if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
-    image="${repository}:latest"
-    docker buildx build \
-      --push \
-      --no-cache \
-      --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64,linux/amd64 \
-      --build-arg PORT="${dynamo_port}" \
-      --tag "${image}" \
-      --tag "${repository}:${build}" \
-      .
-  else
-    image="${repository}:branch-${build}"
-    docker buildx build \
-      --push \
-      --no-cache \
-      --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64,linux/amd64 \
-      --build-arg PORT="${dynamo_port}" \
-      --tag "${image}" \
-      .
-  fi
-
-  docker buildx rm
-}
-
 read_tables
 echo "1. Retrieve schemas..."
 retrieve_schemas "${tables[@]}"

--- a/hooks/functions
+++ b/hooks/functions
@@ -65,3 +65,8 @@ function retrieve_schemas {
   done
 }
 
+# Reads a describe-table JSON and converts it to a create-table JSON
+function generate_create_json {
+  local input_json_file="$1"
+  echo $(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${input_json_file}")
+}

--- a/hooks/functions
+++ b/hooks/functions
@@ -99,3 +99,37 @@ function create_database {
   # Stop running local dynamo
   docker stop "${local_dynamo_container_id}"
 }
+
+# Builds the multi-arch image and publishes it
+function build_and_publish {
+  cd "${script_dir}"
+  local dynamo_port
+  dynamo_port="${BUILDKITE_PLUGIN_DYNAMODB_IMAGE_PORT:-8000}"
+  build="${BUILDKITE_BUILD_NUMBER:-}"
+  repository="$BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY"
+  docker buildx create --use
+  if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
+    image="${repository}:latest"
+    docker buildx build \
+      --push \
+      --no-cache \
+      --file "${script_dir}"/Dockerfile \
+      --platform linux/arm64,linux/amd64 \
+      --build-arg PORT="${dynamo_port}" \
+      --tag "${image}" \
+      --tag "${repository}:${build}" \
+      .
+  else
+    image="${repository}:branch-${build}"
+    docker buildx build \
+      --push \
+      --no-cache \
+      --file "${script_dir}"/Dockerfile \
+      --platform linux/arm64,linux/amd64 \
+      --build-arg PORT="${dynamo_port}" \
+      --tag "${image}" \
+      .
+  fi
+
+  docker buildx rm
+}

--- a/hooks/functions
+++ b/hooks/functions
@@ -2,6 +2,7 @@
 
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
 tmp_dir="${script_dir}/tmp"
+mkdir -p "${tmp_dir}"
 
 function check_null {
   local var_name="$1"

--- a/hooks/functions
+++ b/hooks/functions
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function check_null {
+  local var_name="$1"
+  local var_value="${!var_name:-}"
+  if [[ -z "$var_value" ]]; then
+    echo "The environment variable $var_name must be set."
+    exit 1
+  fi
+}
+
+# Read a plugin property of type [array, string] into a Bash array. Buildkite
+# exposes a string value at BUILDKITE_PLUGIN_{NAME}_{KEY}, and array values at
+# BUILDKITE_PLUGIN_{NAME}_{KEY}_{IDX}.
+function read_list_property {
+  local prefix="BUILDKITE_PLUGIN_DYNAMODB_IMAGE_${1}"
+  local property="${prefix}_0"
+  result=()
+  if [[ -n ${!property:-} ]]; then
+    local i=0
+    local property="${prefix}_${i}"
+    while [[ -n ${!property:-} ]]; do
+      result+=("${!property}")
+      i=$((i + 1))
+      property="${prefix}_${i}"
+    done
+  elif [[ -n ${!prefix:-} ]]; then
+    result+=("${!prefix}")
+  fi
+  [[ ${#result[@]} -gt 0 ]] || return 1
+}
+
+# Read tables into an array
+function read_tables {
+  if read_list_property 'TABLES'; then
+    for table in "${result[@]}"; do
+      tables+=("${table}")
+    done
+  else
+    echo "A list of tables must be provided."
+    exit 1
+  fi
+}
+
+function read_tables_with_output {
+  read_tables
+  echo "${tables[@]}" 
+}

--- a/hooks/functions
+++ b/hooks/functions
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
+tmp_dir="${script_dir}/tmp"
+
 function check_null {
   local var_name="$1"
   local var_value="${!var_name:-}"
@@ -42,7 +45,23 @@ function read_tables {
   fi
 }
 
+# This is only used to test the read_tables function
 function read_tables_with_output {
   read_tables
   echo "${tables[@]}" 
 }
+
+# Retrieves schemas for a list of tables and saves them as JSON
+function retrieve_schemas {
+  local tables=("$@")
+  for table in "${tables[@]}"; do
+    local schema_file="${tmp_dir}/${table}.json"
+    local dynamo_json
+    dynamo_json=$(aws dynamodb describe-table \
+      --table-name "${table}" \
+      --output json)
+    echo "${dynamo_json}"
+    echo "${dynamo_json}" > "${schema_file}"
+  done
+}
+

--- a/hooks/functions
+++ b/hooks/functions
@@ -70,3 +70,32 @@ function generate_create_json {
   local input_json_file="$1"
   echo $(jq '.Table | {TableName, KeySchema, AttributeDefinitions} + (try {LocalSecondaryIndexes: [ .LocalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + (try {GlobalSecondaryIndexes: [ .GlobalSecondaryIndexes[] | {IndexName, KeySchema, Projection} ]} // {}) + {BillingMode: "PAY_PER_REQUEST"}' "${input_json_file}")
 }
+
+# Creates the necessary database files and saves them to the local filesystem
+function create_database {
+  local tables=("$@")
+  local local_dynamo_port local_dynamo_container_id local_dynamo_endpoint container_port
+  
+  # Start dynamo locally
+  local_dynamo_port=8000
+  docker pull amazon/dynamodb-local:latest
+  local_dynamo_container_id=$(docker run -d -p 0:"${local_dynamo_port}" amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port "${local_dynamo_port}" -sharedDb)
+  sleep 5 # TODO: This gives the container a bit of time to start up, but it would be better to poll for when its up instead
+
+  # Create the tables
+  container_port=$(docker port "${local_dynamo_container_id}" "${local_dynamo_port}" | cut -d':' -f2)
+  local_dynamo_endpoint=http://localhost:"${container_port}"
+  for table in "${tables[@]}"; do
+    local schema_file table_json
+    schema_file="${tmp_dir}/${table}.json"
+    table_json=$(generate_create_json "${schema_file}")
+    aws dynamodb create-table --cli-input-json "${table_json}" --region "local" --endpoint "${local_dynamo_endpoint}"
+  done
+  aws dynamodb list-tables --region "local" --endpoint "${local_dynamo_endpoint}"
+  
+  # Save the database file so that we can use it in the build
+  docker cp "${local_dynamo_container_id}":/home/dynamodblocal/shared-local-instance.db "${tmp_dir}"/shared-local-instance.db
+
+  # Stop running local dynamo
+  docker stop "${local_dynamo_container_id}"
+}

--- a/mock/TestTableGSI.json
+++ b/mock/TestTableGSI.json
@@ -1,0 +1,63 @@
+{
+  "Table": {
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "ID",
+        "AttributeType": "N"
+      },
+      {
+        "AttributeName": "Name",
+        "AttributeType": "S"
+      },
+      {
+        "AttributeName": "SecondaryID",
+        "AttributeType": "N"
+      }
+    ],
+    "TableName": "SampleTable",
+    "KeySchema": [
+      {
+        "AttributeName": "ID",
+        "KeyType": "HASH"
+      },
+      {
+        "AttributeName": "Name",
+        "KeyType": "RANGE"
+      }
+    ],
+    "TableStatus": "ACTIVE",
+    "CreationDateTime": "2023-01-01T00:00:00.000000Z",
+    "ProvisionedThroughput": {
+      "NumberOfDecreasesToday": 0,
+      "ReadCapacityUnits": 5,
+      "WriteCapacityUnits": 5
+    },
+    "TableSizeBytes": 0,
+    "ItemCount": 0,
+    "TableArn": "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable",
+    "BillingModeSummary": {
+      "BillingMode": "PROVISIONED",
+      "LastUpdateToPayPerRequestDateTime": "2023-01-01T00:00:00.000000Z"
+    },
+    "GlobalSecondaryIndexes": [
+      {
+          "IndexName": "TestTableGSI",
+          "KeySchema": [
+              {
+                  "AttributeName": "SecondaryID",
+                  "KeyType": "HASH"
+              }
+          ],
+          "Projection": {
+              "ProjectionType": "ALL"
+          },
+          "IndexStatus": "ACTIVE",
+          "ItemCount": 0,
+          "ProvisionedThroughput": {
+              "ReadCapacityUnits": 5,
+              "WriteCapacityUnits": 5
+          }
+      }
+  ]
+  }
+}

--- a/mock/TestTableLSI.json
+++ b/mock/TestTableLSI.json
@@ -1,0 +1,59 @@
+{
+  "Table": {
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "ID",
+        "AttributeType": "N"
+      },
+      {
+        "AttributeName": "Name",
+        "AttributeType": "S"
+      },
+      {
+        "AttributeName": "TernaryID",
+        "AttributeType": "N"
+      }
+    ],
+    "TableName": "SampleTable",
+    "KeySchema": [
+      {
+        "AttributeName": "ID",
+        "KeyType": "HASH"
+      },
+      {
+        "AttributeName": "Name",
+        "KeyType": "RANGE"
+      }
+    ],
+    "TableStatus": "ACTIVE",
+    "CreationDateTime": "2023-01-01T00:00:00.000000Z",
+    "ProvisionedThroughput": {
+      "NumberOfDecreasesToday": 0,
+      "ReadCapacityUnits": 5,
+      "WriteCapacityUnits": 5
+    },
+    "TableSizeBytes": 0,
+    "ItemCount": 0,
+    "TableArn": "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable",
+    "BillingModeSummary": {
+      "BillingMode": "PROVISIONED",
+      "LastUpdateToPayPerRequestDateTime": "2023-01-01T00:00:00.000000Z"
+    },
+    "LocalSecondaryIndexes": [
+      {
+          "IndexName": "TestTableLSI",
+          "KeySchema": [
+              {
+                  "AttributeName": "TernaryID",
+                  "KeyType": "HASH"
+              }
+          ],
+          "Projection": {
+              "ProjectionType": "ALL"
+          },
+          "ItemCount": 0,
+          "IndexSizeBytes": 0
+      }
+  ]
+  }
+}

--- a/mock/TestTableNoIndexes.json
+++ b/mock/TestTableNoIndexes.json
@@ -1,0 +1,39 @@
+{
+  "Table": {
+    "AttributeDefinitions": [
+      {
+        "AttributeName": "ID",
+        "AttributeType": "N"
+      },
+      {
+        "AttributeName": "Name",
+        "AttributeType": "S"
+      }
+    ],
+    "TableName": "SampleTable",
+    "KeySchema": [
+      {
+        "AttributeName": "ID",
+        "KeyType": "HASH"
+      },
+      {
+        "AttributeName": "Name",
+        "KeyType": "RANGE"
+      }
+    ],
+    "TableStatus": "ACTIVE",
+    "CreationDateTime": "2023-01-01T00:00:00.000000Z",
+    "ProvisionedThroughput": {
+      "NumberOfDecreasesToday": 0,
+      "ReadCapacityUnits": 5,
+      "WriteCapacityUnits": 5
+    },
+    "TableSizeBytes": 0,
+    "ItemCount": 0,
+    "TableArn": "arn:aws:dynamodb:us-east-1:123456789012:table/TestTable",
+    "BillingModeSummary": {
+      "BillingMode": "PROVISIONED",
+      "LastUpdateToPayPerRequestDateTime": "2023-01-01T00:00:00.000000Z"
+    }
+  }
+}

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -54,3 +54,38 @@ mkdir -p "/plugin/hooks/tmp"
 
   unstub aws
 }
+
+@test "generate_create_json pulls out all required fields from the schema" {
+  local test_file="/plugin/mock/TestTableNoIndexes.json"
+  run generate_create_json ${test_file}
+
+  assert_output --partial '"TableName": "SampleTable"'
+  assert_output --partial '"KeySchema": [ { "AttributeName": "ID", "KeyType": "HASH" }, { "AttributeName": "Name", "KeyType": "RANGE" } ]'
+  assert_output --partial '"AttributeDefinitions": [ { "AttributeName": "ID", "AttributeType": "N" }, { "AttributeName": "Name", "AttributeType": "S" } ]'
+  assert_success
+}
+
+@test "generate_create_json ignores the schema billing mode and always sets it to PAY_PER_REQUEST" {
+  local test_file="/plugin/mock/TestTableNoIndexes.json"
+  run generate_create_json ${test_file}
+
+  assert_output --partial '"BillingMode": "PAY_PER_REQUEST"'
+  assert_success
+}
+
+@test "generate_create_json includes the GSI when it is present" {
+  local test_file="/plugin/mock/TestTableGSI.json"
+  run generate_create_json ${test_file}
+
+  assert_output --partial '"GlobalSecondaryIndexes": [ { "IndexName": "TestTableGSI", "KeySchema": [ { "AttributeName": "SecondaryID", "KeyType": "HASH" } ], "Projection": { "ProjectionType": "ALL" } } ]'
+  assert_success
+}
+
+@test "generate_create_json includes the LSI when it is present" {
+  local test_file="/plugin/mock/TestTableLSI.json"
+  run generate_create_json ${test_file}
+
+  assert_output --partial '"LocalSecondaryIndexes": [ { "IndexName": "TestTableLSI", "KeySchema": [ { "AttributeName": "TernaryID", "KeyType": "HASH" } ]'
+  assert_success
+}
+

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -1,7 +1,10 @@
 #!/usr/bin/env bats
 
+export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 load "$BATS_PLUGIN_PATH/load.bash"
 load "$PWD/hooks/functions"
+
+mkdir -p "/plugin/hooks/tmp"
 
 @test "check_null does not throw when an environment variable exists" {
   export BUILDKITE_BUILD_NUMBER="1234"
@@ -24,13 +27,30 @@ load "$PWD/hooks/functions"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_0="my-table-0"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_1="my-table-1"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_2="my-table-2"
-  run read_tables_with_output 'TABLES'
+  run read_tables_with_output
   assert_output "my-table-0 my-table-1 my-table-2"
   assert_success
 }
 
 @test "read_tables throws when no tables are defined" {
-  run read_tables 'TABLES'
+  run read_tables
   assert_output "A list of tables must be provided."
   assert_failure
+}
+
+@test "retrieve_schemas should retrieve the schemas for each table using the aws cli" {
+  stub aws \
+    "dynamodb describe-table --table-name my-table-0 --output json : echo {"TableName": "my-table-0"}" \
+    "dynamodb describe-table --table-name my-table-1 --output json : echo {"TableName": "my-table-1"}" \
+    "dynamodb describe-table --table-name my-table-2 --output json : echo {"TableName": "my-table-2"}"
+
+  local test_tables=("my-table-0" "my-table-1" "my-table-2")
+  run retrieve_schemas "${test_tables[@]}"
+
+  assert_output --partial {TableName: my-table-0}
+  assert_output --partial {TableName: my-table-1}
+  assert_output --partial {TableName: my-table-2}
+  assert_success
+
+  unstub aws
 }

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -6,24 +6,24 @@ load "$PWD/hooks/functions"
 
 mkdir -p "/plugin/hooks/tmp"
 
-@test "check_null does not throw when an environment variable exists" {
+@test "check_null: does not throw when an environment variable exists" {
   export BUILDKITE_BUILD_NUMBER="1234"
   run check_null BUILDKITE_BUILD_NUMBER
   assert_success
 }
 
-@test "check_null throws when an environment variable does not exist" {
+@test "check_null: throws when an environment variable does not exist" {
   run check_null BUILDKITE_BUILD_NUMBER
   assert_failure
 }
 
-@test "check_null throws when an environment variable is empty" {
+@test "check_null: throws when an environment variable is empty" {
   export BUILDKITE_BUILD_NUMBER=""
   run check_null BUILDKITE_BUILD_NUMBER
   assert_failure
 }
 
-@test "read_tables reads the tables into an array" {
+@test "read_tables: reads the tables into an array" {
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_0="my-table-0"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_1="my-table-1"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_2="my-table-2"
@@ -38,7 +38,7 @@ mkdir -p "/plugin/hooks/tmp"
   assert_failure
 }
 
-@test "retrieve_schemas should retrieve the schemas for each table using the aws cli" {
+@test "retrieve_schemas: should retrieve the schemas for each table using the aws cli" {
   stub aws \
     "dynamodb describe-table --table-name my-table-0 --output json : echo {"TableName": "my-table-0"}" \
     "dynamodb describe-table --table-name my-table-1 --output json : echo {"TableName": "my-table-1"}" \
@@ -55,7 +55,7 @@ mkdir -p "/plugin/hooks/tmp"
   unstub aws
 }
 
-@test "generate_create_json pulls out all required fields from the schema" {
+@test "generate_create_json: pulls out all required fields from the schema" {
   local test_file="/plugin/mock/TestTableNoIndexes.json"
   run generate_create_json ${test_file}
 
@@ -65,7 +65,7 @@ mkdir -p "/plugin/hooks/tmp"
   assert_success
 }
 
-@test "generate_create_json ignores the schema billing mode and always sets it to PAY_PER_REQUEST" {
+@test "generate_create_json: ignores the schema billing mode and always sets it to PAY_PER_REQUEST" {
   local test_file="/plugin/mock/TestTableNoIndexes.json"
   run generate_create_json ${test_file}
 
@@ -73,7 +73,7 @@ mkdir -p "/plugin/hooks/tmp"
   assert_success
 }
 
-@test "generate_create_json includes the GSI when it is present" {
+@test "generate_create_json: includes the GSI when it is present" {
   local test_file="/plugin/mock/TestTableGSI.json"
   run generate_create_json ${test_file}
 
@@ -81,7 +81,7 @@ mkdir -p "/plugin/hooks/tmp"
   assert_success
 }
 
-@test "generate_create_json includes the LSI when it is present" {
+@test "generate_create_json: includes the LSI when it is present" {
   local test_file="/plugin/mock/TestTableLSI.json"
   run generate_create_json ${test_file}
 
@@ -89,7 +89,7 @@ mkdir -p "/plugin/hooks/tmp"
   assert_success
 }
 
-@test "create_database creates each of the tables locally and saves the resulting database" {
+@test "create_database: creates each of the tables locally and saves the resulting database" {
   local test_tables=("my-table-0" "my-table-1" "my-table-2")
 
   stub aws \

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -130,7 +130,7 @@ mkdir -p "/plugin/hooks/tmp"
   unstub sleep
 }
 
-@test "build_and_publish: builds and publishes the image with a branch tag when on a branch" {
+@test "build_and_publish: builds and publishes the image with a build number branch tag when on a branch" {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="master"
   export BUILDKITE_BRANCH="my-branch"
   export BUILDKITE_BUILD_NUMBER="1234"
@@ -151,7 +151,7 @@ mkdir -p "/plugin/hooks/tmp"
   unstub docker
 }
 
-@test "build_and_publish: builds and publishes the image with the latest tag and a build tag when on the main branch" {
+@test "build_and_publish: builds and publishes the image with the latest tag and a build number tag when on the main branch" {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="master"
   export BUILDKITE_BRANCH="master"
   export BUILDKITE_BUILD_NUMBER="1234"

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+load "$BATS_PLUGIN_PATH/load.bash"
+load "$PWD/hooks/functions"
+
+@test "check_null does not throw when an environment variable exists" {
+  export BUILDKITE_BUILD_NUMBER="1234"
+  run check_null BUILDKITE_BUILD_NUMBER
+  assert_success
+}
+
+@test "check_null throws when an environment variable does not exist" {
+  run check_null BUILDKITE_BUILD_NUMBER
+  assert_failure
+}
+
+@test "check_null throws when an environment variable is empty" {
+  export BUILDKITE_BUILD_NUMBER=""
+  run check_null BUILDKITE_BUILD_NUMBER
+  assert_failure
+}
+
+@test "read_tables reads the tables into an array" {
+  export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_0="my-table-0"
+  export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_1="my-table-1"
+  export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_TABLES_2="my-table-2"
+  run read_tables_with_output 'TABLES'
+  assert_output "my-table-0 my-table-1 my-table-2"
+  assert_success
+}
+
+@test "read_tables throws when no tables are defined" {
+  run read_tables 'TABLES'
+  assert_output "A list of tables must be provided."
+  assert_failure
+}


### PR DESCRIPTION
Adds in [BATS](https://github.com/bats-core/bats-core) unit tests for the functions used in the plugin. To enable testing each function in isolation, I refactored the plugin so that the functions were split out into a separate `functions` file. This PR doesn't add any functional changes to how the plugin works.