### PR TITLE
Remove amd images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![GitHub Release](https://img.shields.io/github/release/seek-oss/dynamodb-image-buildkite-plugin.svg)](https://github.com/seek-oss/dynamodb-image-buildkite-plugin/releases)
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that introspects the schema of DynamoDB tables and then publishes multi-arch (linux/arm64 and linux/amd64) [amazon/dynamodb-local](https://hub.docker.com/r/amazon/dynamodb-local) images with these schemas to [ECR](https://aws.amazon.com/ecr/).
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) that introspects the schema of DynamoDB tables and then publishes linux/arm64 [amazon/dynamodb-local](https://hub.docker.com/r/amazon/dynamodb-local) images with these schemas to [ECR](https://aws.amazon.com/ecr/).
+
+Publishing multi-architecture images is no longer supported. These were removed since all observed plugin usage occurs on arm64 architectures and it simplifies image tagging in [ECR](https://aws.amazon.com/ecr/). If you have a use case for multi-architecture images, please open an issue.
 
 ## Usage Requirements
 
@@ -19,7 +21,7 @@ This will create an [amazon/dynamodb-local](https://hub.docker.com/r/amazon/dyna
 steps:
   - label: Publish Dynamo Image
     plugins:
-      - seek-oss/dynamodb-image#v1.4.0:
+      - seek-oss/dynamodb-image#v2.0.0:
           tables:
             - Jobs
             - Applications
@@ -32,7 +34,7 @@ To run DynamoDB on a specific port when a container is run with the image, the `
 steps:
   - label: Publish Dynamo Image
     plugins:
-      - seek-oss/dynamodb-image#v1.4.0:
+      - seek-oss/dynamodb-image#v2.0.0:
           tables:
             - Jobs
             - Applications

--- a/hooks/functions
+++ b/hooks/functions
@@ -49,7 +49,7 @@ function read_tables {
 # This is only used to test the read_tables function
 function read_tables_with_output {
   read_tables
-  echo "${tables[@]}" 
+  echo "${tables[@]}"
 }
 
 # Retrieves schemas for a list of tables and saves them as JSON
@@ -76,7 +76,7 @@ function generate_create_json {
 function create_database {
   local tables=("$@")
   local local_dynamo_port local_dynamo_container_id local_dynamo_endpoint container_port
-  
+
   # Start dynamo locally
   local_dynamo_port=8000
   docker pull amazon/dynamodb-local:latest
@@ -93,7 +93,7 @@ function create_database {
     aws dynamodb create-table --cli-input-json "${table_json}" --region "local" --endpoint "${local_dynamo_endpoint}"
   done
   aws dynamodb list-tables --region "local" --endpoint "${local_dynamo_endpoint}"
-  
+
   # Save the database file so that we can use it in the build
   docker cp "${local_dynamo_container_id}":/home/dynamodblocal/shared-local-instance.db "${tmp_dir}"/shared-local-instance.db
 
@@ -115,7 +115,7 @@ function build_and_publish {
       --push \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64,linux/amd64 \
+      --platform linux/arm64 \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       --tag "${repository}:${build}" \
@@ -126,7 +126,7 @@ function build_and_publish {
       --push \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64,linux/amd64 \
+      --platform linux/arm64 \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       .

--- a/hooks/functions
+++ b/hooks/functions
@@ -107,27 +107,26 @@ function build_and_publish {
   dynamo_port="${BUILDKITE_PLUGIN_DYNAMODB_IMAGE_PORT:-8000}"
   build="${BUILDKITE_BUILD_NUMBER:-}"
   repository="$BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY"
-  docker buildx create --use
+
   if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
     image="${repository}:latest"
-    docker build build \
-      --push \
+    docker build \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       --tag "${repository}:${build}" \
       .
+    docker push "${image}"
+    docker push "${repository}:${build}"
   else
     image="${repository}:branch-${build}"
-    docker build build \
-      --push \
+    docker build \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       .
+    docker push "${image}"
   fi
-
-  docker buildx rm
 }

--- a/hooks/functions
+++ b/hooks/functions
@@ -101,7 +101,6 @@ function create_database {
   docker stop "${local_dynamo_container_id}"
 }
 
-# Builds the multi-arch image and publishes it
 function build_and_publish {
   cd "${script_dir}"
   local dynamo_port
@@ -111,22 +110,20 @@ function build_and_publish {
   docker buildx create --use
   if [[ ${BUILDKITE_BRANCH} == "${BUILDKITE_PIPELINE_DEFAULT_BRANCH}" ]]; then
     image="${repository}:latest"
-    docker buildx build \
+    docker build build \
       --push \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64 \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       --tag "${repository}:${build}" \
       .
   else
     image="${repository}:branch-${build}"
-    docker buildx build \
+    docker build build \
       --push \
       --no-cache \
       --file "${script_dir}"/Dockerfile \
-      --platform linux/arm64 \
       --build-arg PORT="${dynamo_port}" \
       --tag "${image}" \
       .

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -103,7 +103,7 @@ mkdir -p "/plugin/hooks/tmp"
     "run -d -p 0:8000 amazon/dynamodb-local:latest -jar DynamoDBLocal.jar -port 8000 -sharedDb : echo 123456789" \
     "port 123456789 8000 : echo 0.0.0.0:56789" \
     "cp 123456789:/home/dynamodblocal/shared-local-instance.db /plugin/hooks/tmp/shared-local-instance.db : echo copied database" \
-    "stop 123456789 : echo stopped local dynamo" 
+    "stop 123456789 : echo stopped local dynamo"
 
   stub sleep \
     "5 : echo sleeping for 5 seconds while dynamo starts"
@@ -138,7 +138,7 @@ mkdir -p "/plugin/hooks/tmp"
 
   stub docker \
     "buildx create --use : echo creating builder instance" \
-    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64,linux/amd64 --build-arg PORT=8000 --tag my-registry/my-image:branch-1234 . : echo building and publishing branch image" \
+    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64 --build-arg PORT=8000 --tag my-registry/my-image:branch-1234 . : echo building and publishing branch image" \
     "buildx rm : echo removing builder instance"
 
   run build_and_publish
@@ -159,7 +159,7 @@ mkdir -p "/plugin/hooks/tmp"
 
   stub docker \
     "buildx create --use : echo creating builder instance" \
-    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64,linux/amd64 --build-arg PORT=8000 --tag my-registry/my-image:latest --tag my-registry/my-image:1234 . : echo building and publishing latest image" \
+    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64 --build-arg PORT=8000 --tag my-registry/my-image:latest --tag my-registry/my-image:1234 . : echo building and publishing latest image" \
     "buildx rm : echo removing builder instance"
 
   run build_and_publish

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -137,15 +137,13 @@ mkdir -p "/plugin/hooks/tmp"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY="my-registry/my-image"
 
   stub docker \
-    "buildx create --use : echo creating builder instance" \
-    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64 --build-arg PORT=8000 --tag my-registry/my-image:branch-1234 . : echo building and publishing branch image" \
-    "buildx rm : echo removing builder instance"
+    "build --no-cache --file /plugin/hooks/Dockerfile --build-arg PORT=8000 --tag my-registry/my-image:branch-1234 . : echo building and publishing branch image" \
+    "push my-registry/my-image:branch-1234 : echo pushing branch image"
 
   run build_and_publish
 
-  assert_output --partial "creating builder instance"
   assert_output --partial "building and publishing branch image"
-  assert_output --partial "removing builder instance"
+  assert_output --partial "pushing branch image"
   assert_success
 
   unstub docker
@@ -158,15 +156,15 @@ mkdir -p "/plugin/hooks/tmp"
   export BUILDKITE_PLUGIN_DYNAMODB_IMAGE_REPOSITORY="my-registry/my-image"
 
   stub docker \
-    "buildx create --use : echo creating builder instance" \
-    "buildx build --push --no-cache --file /plugin/hooks/Dockerfile --platform linux/arm64 --build-arg PORT=8000 --tag my-registry/my-image:latest --tag my-registry/my-image:1234 . : echo building and publishing latest image" \
-    "buildx rm : echo removing builder instance"
+    "build --no-cache --file /plugin/hooks/Dockerfile --build-arg PORT=8000 --tag my-registry/my-image:latest --tag my-registry/my-image:1234 . : echo building and publishing latest image" \
+    "push my-registry/my-image:latest : echo pushing latest image" \
+    "push my-registry/my-image:1234 : echo pushing build number image"
 
   run build_and_publish
 
-  assert_output --partial "creating builder instance"
   assert_output --partial "building and publishing latest image"
-  assert_output --partial "removing builder instance"
+  assert_output --partial "pushing latest image"
+  assert_output --partial "pushing build number image"
   assert_success
 
   unstub docker


### PR DESCRIPTION
It's [only us using this](https://github.com/search?q=%22seek-oss%2Fdynamodb-image%22&type=code) and [we only use arm ](https://github.com/search?q=repo%3ASEEK-Jobs%2Fbuild-agency-strategies+%22%23+Indirect%22&type=code). 

This aims to fix the issue that we faced where building for multiple architectures leading to only a manifest file being uploaded with tags leaving the underling images technically tag-less. 

The life cycle policy then deleted the latest image making our builds fail.